### PR TITLE
Fix not building correctly or not running in Chrome for Windows

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+INLINE_RUNTIME_CHUNK=false

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install
 Build the project:
 
 ```
-npm run build-chrome
+npm run build
 ```
 
 ## Run it in chrome

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "build-chrome": "INLINE_RUNTIME_CHUNK=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Caused by the Unix/Windows differences when setting the INLINE_RUNTIME_CHUNK environment variable